### PR TITLE
Update call-to-action button with link to HackUTD VII

### DIFF
--- a/data/callToAction.json
+++ b/data/callToAction.json
@@ -4,7 +4,7 @@
         "link": "http://eepurl.com/hdjJMz"
     },
     {
-        "text": "Check out our Game Jam event",
-        "link": "https://gamejam.hackutd.co/"
+        "text": "Check out our Hackathon event",
+        "link": "https://2021.hackutd.co/"
     }
 ]

--- a/data/callToAction.json
+++ b/data/callToAction.json
@@ -4,7 +4,7 @@
         "link": "http://eepurl.com/hdjJMz"
     },
     {
-        "text": "Check out our Hackathon event",
+        "text": "Register for HackUTD VII: The VII Seas",
         "link": "https://2021.hackutd.co/"
     }
 ]

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -3,32 +3,36 @@
     <section class="events-page background-scrim">
       <h1 class="page-title">Our Flagship Events</h1>
       <div class="md:flex">
-        <div class="event-card" @click="redirectGameJam">
-          <picture>
-            <source srcset="../assets/logo-square-dark.svg" media="(prefers-color-scheme: light)">
-            <source srcset="../assets/logo-square-white.svg" media="(prefers-color-scheme: dark)">
-            <img 
-              src="../assets/logo-square-dark.svg" 
+        <a href="https://gamejam.hackutd.co/">
+          <div class="event-card">
+            <picture>
+              <source srcset="../assets/logo-square-dark.svg" media="(prefers-color-scheme: light)">
+              <source srcset="../assets/logo-square-white.svg" media="(prefers-color-scheme: dark)">
+              <img 
+                src="../assets/logo-square-dark.svg" 
+                class="event-card--image"
+                />
+            </picture>
+            <div class="">
+              <h2 class="event-card--title">HackUTD Game Jam</h2>
+              <div class="event-card--description">An experimental online experience.</div>
+              <div class="event-card--cta">October 25th-31st 2020</div>
+            </div>
+          </div>
+        </a>
+        <a href="https://2021.hackutd.co/">
+          <div class="event-card">
+            <img
+              src="../assets/logo-square-orange.svg"
               class="event-card--image"
-              />
-          </picture>
-          <div class="">
-            <h2 class="event-card--title">HackUTD Game Jam</h2>
-            <div class="event-card--description">An experimental online experience.</div>
-            <div class="event-card--cta">October 25th-31st 2020</div>
+            />
+            <div class="">
+              <h2 class="event-card--title">HackUTD</h2>
+              <div class="event-card--description">Our hackathon for everyone.</div>
+              <div class="event-card--cta">February 27-28th 2021</div>
+            </div>
           </div>
-        </div>
-        <div class="event-card" @click="redirectHackUTD">
-          <img
-            src="../assets/logo-square-orange.svg"
-            class="event-card--image"
-          />
-          <div class="">
-            <h2 class="event-card--title">HackUTD</h2>
-            <div class="event-card--description">Our hackathon for everyone.</div>
-            <div class="event-card--cta">February 27-28th 2021</div>
-          </div>
-        </div>
+        </a>
       </div>
     </section>
   </Layout>
@@ -47,12 +51,6 @@ export default {
   methods: {
     prettifyDate(date) {
       return new Date(date).toString();
-    },
-    redirectGameJam() {
-      window.location.href = "https://gamejam.hackutd.co/";
-    },
-    redirectHackUTD() {
-      window.location.href = "https://2021.hackutd.co/";
     }
   },
 };

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -18,7 +18,7 @@
             <div class="event-card--cta">October 25th-31st 2020</div>
           </div>
         </div>
-        <div class="event-card">
+        <div class="event-card" @click="redirectHackUTD">
           <img
             src="../assets/logo-square-orange.svg"
             class="event-card--image"
@@ -50,6 +50,9 @@ export default {
     },
     redirectGameJam() {
       window.location.href = "https://gamejam.hackutd.co/";
+    },
+    redirectHackUTD() {
+      window.location.href = "https://2021.hackutd.co/";
     }
   },
 };


### PR DESCRIPTION
This latest post on the HackUTD twitter says to go to the link in the bio to register for HackUTD VII but the website is missing the link to the registration page so I changed the following: 

- Added a link on the events page to the hackutd vii page (https://2021.gamejam.com)
- One of the buttons on the front page of the website now says "Check out our Hackathon event" instead of  "Check out our GameJam event" -> feel free to change the wording on this

