### PR TITLE
Fix background image not displaying correctly on Firefox

### DIFF
--- a/src/layouts/GeneralLayout.vue
+++ b/src/layouts/GeneralLayout.vue
@@ -34,7 +34,7 @@ export default {
 #app {
   @apply h-full;
   background: url('../assets/starsbg-blue.svg') no-repeat fixed;
-  background-size: 100%;
+  background-size: 100% 100%;
   overflow: auto;
 }
 

--- a/src/layouts/GeneralLayout.vue
+++ b/src/layouts/GeneralLayout.vue
@@ -33,7 +33,7 @@ export default {
 <style lang="postcss">
 #app {
   @apply h-full;
-  background: url('../assets/starsbg-blue.svg') no-repeat fixed 100%;
+  background: url('../assets/starsbg-blue.svg') no-repeat fixed;
   background-size: 100%;
   overflow: auto;
 }

--- a/src/layouts/GeneralLayout.vue
+++ b/src/layouts/GeneralLayout.vue
@@ -34,6 +34,7 @@ export default {
 #app {
   @apply h-full;
   background: url('../assets/starsbg-blue.svg') no-repeat fixed 100%;
+  background-size: 100%;
   overflow: auto;
 }
 


### PR DESCRIPTION
Tested with Firefox on my local machine (Windows 10) and it appears to be working correctly

closes #79 